### PR TITLE
Rendering improvements

### DIFF
--- a/Api/Block/Product/ShippingSurchargeAmountInterface.php
+++ b/Api/Block/Product/ShippingSurchargeAmountInterface.php
@@ -8,6 +8,7 @@ namespace SwiftOtter\ShippingSurcharge\Api\Block\Product;
 
 interface ShippingSurchargeAmountInterface
 {
+    public function hasSurcharge(): bool;
     public function getSurcharge(): string;
     public function getSurchargeLabel(): string;
 }

--- a/Block/ShippingSurchargeAmount.php
+++ b/Block/ShippingSurchargeAmount.php
@@ -15,12 +15,21 @@ abstract class ShippingSurchargeAmount extends Template implements ShippingSurch
      * @var string
      */
     protected $surchargeLabel;
+    private $priceCurrency;
 
-    abstract public function getSurcharge(): string;
+    public function __construct(
+        Template\Context $context,
+        \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
+        array $data = []
+        )
+    {
+        $this->priceCurrency = $priceCurrency;
+        parent::__construct($context, $data);
+    }
 
     protected function formatSurcharge(float $amount): string
     {
-        return sprintf('%.2f', $amount);
+        return $this->priceCurrency->convertAndFormat($amount, false);
     }
 
     public function getSurchargeLabel(): string

--- a/Block/ShippingSurchargeAmount/Cart/Item.php
+++ b/Block/ShippingSurchargeAmount/Cart/Item.php
@@ -19,6 +19,11 @@ class Item extends ShippingSurchargeAmount implements ShippingSurchargeAmountInt
 
     protected $surchargeLabel = 'Handling';
 
+    public function hasSurcharge(): bool
+    {
+        return (bool) $this->quoteItem->getProduct()->getData('shipping_surcharge');
+    }
+
     public function getSurcharge(): string
     {
         return $this->formatSurcharge($this->quoteItem->getProduct()->getData('shipping_surcharge') * $this->quoteItem->getQty());

--- a/Block/ShippingSurchargeAmount/Product.php
+++ b/Block/ShippingSurchargeAmount/Product.php
@@ -23,13 +23,19 @@ class Product extends ShippingSurchargeAmount implements ShippingSurchargeAmount
     public function __construct(
         ProductRepositoryInterface $productRepository,
         Template\Context $context,
+        \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
         array $data = []
     ) {
-        parent::__construct($context, $data);
+        parent::__construct($context, $priceCurrency, $data);
 
         $this->surchargeLabel = 'Handling';
         $this->productRepository = $productRepository;
         $this->product = $this->loadProduct();
+    }
+
+    public function hasSurcharge(): bool
+    {
+        return (bool) $this->product->getData('shipping_surcharge');
     }
 
     public function getSurcharge(): string

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -3,4 +3,8 @@
     <referenceBlock name="product.info.addtocart">
         <block name="product.info.addtocart.shipping_surcharge" as="shipping_surcharge" class="SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount\Product" template="price/shipping_surcharge_amount.phtml" />
     </referenceBlock>
+
+    <referenceBlock name="product.info.addtocart.additional">
+        <block name="product.info.addtocart.shipping_surcharge" as="shipping_surcharge" class="SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount\Product" template="price/shipping_surcharge_amount.phtml" />
+    </referenceBlock>
 </layout>

--- a/view/frontend/templates/price/shipping_surcharge_amount.phtml
+++ b/view/frontend/templates/price/shipping_surcharge_amount.phtml
@@ -7,9 +7,9 @@
 
 <?php /** @var SwiftOtter\ShippingSurcharge\Api\Block\Product\ShippingSurchargeAmountInterface $block */ ?>
 
-<?php if ($surcharge = $block->getSurcharge()): ?>
+<?php if ($block->hasSurcharge()): ?>
 <span class="surcharge">
     <span class="surcharge__label"><?php echo $block->getSurchargeLabel(); ?> </span>
-    <span class="surcharge__amount">$<?php echo $block->getSurcharge(); ?></span>
+    <span class="surcharge__amount"><?php echo $block->getSurcharge(); ?></span>
 </span>
 <?php endif; ?>


### PR DESCRIPTION
I noticed that $0 fees were being displayed: `Handling: $0.00`. I found that the Magento price renderer was easy to implement, so I used that instead. I also added a copy of the the shipping surcharge block to `product.info.addtocart.additional` which some products use. 