### PR TITLE
Add explanatory note

### DIFF
--- a/Api/Block/Product/ShippingSurchargeAmountInterface.php
+++ b/Api/Block/Product/ShippingSurchargeAmountInterface.php
@@ -11,4 +11,5 @@ interface ShippingSurchargeAmountInterface
     public function hasSurcharge(): bool;
     public function getSurcharge(): string;
     public function getSurchargeLabel(): string;
+    public function getSurchargeNote(): string;
 }

--- a/Block/ShippingSurchargeAmount.php
+++ b/Block/ShippingSurchargeAmount.php
@@ -8,6 +8,7 @@ namespace SwiftOtter\ShippingSurcharge\Block;
 
 use Magento\Framework\View\Element\Template;
 use SwiftOtter\ShippingSurcharge\Api\Block\Product\ShippingSurchargeAmountInterface;
+use SwiftOtter\ShippingSurcharge\Setup\Definition\ExplanatoryNoteStaticBlock;
 
 abstract class ShippingSurchargeAmount extends Template implements ShippingSurchargeAmountInterface
 {
@@ -16,20 +17,35 @@ abstract class ShippingSurchargeAmount extends Template implements ShippingSurch
      */
     protected $surchargeLabel;
     private $priceCurrency;
+    private $blockRepository;
+    private $filterProvider;
 
     public function __construct(
         Template\Context $context,
         \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
+        \Magento\Cms\Api\BlockRepositoryInterface $blockRepository,
+        \Magento\Cms\Model\Template\FilterProvider $filterProvider,
         array $data = []
         )
     {
+        $this->blockRepository = $blockRepository;
         $this->priceCurrency = $priceCurrency;
+        $this->filterProvider = $filterProvider;
         parent::__construct($context, $data);
     }
 
     protected function formatSurcharge(float $amount): string
     {
         return $this->priceCurrency->convertAndFormat($amount, false);
+    }
+
+    public function getSurchargeNote(): string
+    {
+        $block = $this->blockRepository->getById(ExplanatoryNoteStaticBlock::ID);
+        $storeId = $this->_storeManager->getStore()->getId();
+        $filteredContent = $this->filterProvider->getBlockFilter()->setStoreId($storeId)->filter($block->getContent());
+
+        return strip_tags($filteredContent);
     }
 
     public function getSurchargeLabel(): string

--- a/Block/ShippingSurchargeAmount/Cart/Item.php
+++ b/Block/ShippingSurchargeAmount/Cart/Item.php
@@ -17,7 +17,7 @@ class Item extends ShippingSurchargeAmount implements ShippingSurchargeAmountInt
      */
     private $quoteItem;
 
-    protected $surchargeLabel = 'Handling';
+    protected $surchargeLabel = 'Additional Shipping Charge';
 
     public function hasSurcharge(): bool
     {

--- a/Block/ShippingSurchargeAmount/Product.php
+++ b/Block/ShippingSurchargeAmount/Product.php
@@ -28,7 +28,7 @@ class Product extends ShippingSurchargeAmount implements ShippingSurchargeAmount
     ) {
         parent::__construct($context, $priceCurrency, $data);
 
-        $this->surchargeLabel = 'Handling';
+        $this->surchargeLabel = 'Additional Shipping Charge';
         $this->productRepository = $productRepository;
         $this->product = $this->loadProduct();
     }

--- a/Block/ShippingSurchargeAmount/Product.php
+++ b/Block/ShippingSurchargeAmount/Product.php
@@ -24,9 +24,11 @@ class Product extends ShippingSurchargeAmount implements ShippingSurchargeAmount
         ProductRepositoryInterface $productRepository,
         Template\Context $context,
         \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
+        \Magento\Cms\Api\BlockRepositoryInterface $blockRepository,
+        \Magento\Cms\Model\Template\FilterProvider $filterProvider,
         array $data = []
     ) {
-        parent::__construct($context, $priceCurrency, $data);
+        parent::__construct($context, $priceCurrency, $blockRepository, $filterProvider, $data);
 
         $this->surchargeLabel = 'Additional Shipping Charge';
         $this->productRepository = $productRepository;

--- a/Setup/Definition/ExplanatoryNoteStaticBlock.php
+++ b/Setup/Definition/ExplanatoryNoteStaticBlock.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @by SwiftOtter, Inc. 2/28/17
+ * @website https://swiftotter.com
+ **/
+
+namespace SwiftOtter\ShippingSurcharge\Setup\Definition;
+
+
+class ExplanatoryNoteStaticBlock
+{
+    const ID = 'surcharge_explanatory_note';
+
+    private $contents = <<<EOD
+<p>An additional shipping charge is required due to the product's size or weight, or because it requires additional packaging.</p>
+EOD;
+
+    public function getData()
+    {
+        return [
+            'title' => 'Surcharge Note',
+            'identifier' => self::ID,
+            'stores' => [0],
+            'is_active' => 1,
+            'content' => $this->contents
+        ];
+    }
+}

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SwiftOtter_ShippingSurcharge" setup_version="1.2.0">
+    <module name="SwiftOtter_ShippingSurcharge" setup_version="1.3.0">
         <sequence>
             <module name="Magento_Shipping" />
         </sequence>

--- a/view/frontend/templates/price/shipping_surcharge_amount.phtml
+++ b/view/frontend/templates/price/shipping_surcharge_amount.phtml
@@ -5,11 +5,29 @@
  **/
 ?>
 
-<?php /** @var SwiftOtter\ShippingSurcharge\Api\Block\Product\ShippingSurchargeAmountInterface $block */ ?>
+<?php /** @var SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount $block */ ?>
 
 <?php if ($block->hasSurcharge()): ?>
-<span class="surcharge">
+<span class="surcharge" data-bind="scope: 'surcharge'">
     <span class="surcharge__label"><?php echo $block->getSurchargeLabel(); ?> </span>
     <span class="surcharge__amount"><?php echo $block->getSurcharge(); ?></span>
+    <span class="surcharge__tooltip"><!-- ko template: 'ui/form/element/helper/tooltip' --><!-- /ko --></span>
 </span>
+<script type="text/x-magento-init">
+   {
+        ".surcharge": {
+            "Magento_Ui/js/core/app": {
+                "components": {
+                    "surcharge": {
+                        "tooltip": {
+                            "link": "<?php echo $block->getUrl('shippinginfo'); ?>",
+                            "description": "<?php echo $block->escapeJsQuote($block->getSurchargeNote(), "\\'"); ?>"
+                        },
+                        "component": "uiElement"
+                    }
+                }
+            }
+        }
+   }
+</script>
 <?php endif; ?>


### PR DESCRIPTION
This adds the ability to add a note that explains the purpose of the extra charge. Instead of a footnote, I leveraged Magento 2's tooltip. It's not actually a tooltip, but a dropdown. The admin panel uses the actual tooltip and I could have used it on the front end, but there was a 23KB difference in the Javascript that runs the respective types. As such, I opted to use CSS to handle the lack in positioning awareness. 

This PR does a few things to facilitate the goal:

- Creates, and then loads a static block to display as the note.
- Filters the static block to ensure that widgets would be processed and JSON won't break when output.
- Add version control to the update script.
- Updates the copy of the surcharge note. (Ideally, this would be in system config.)