### PR TITLE
Fixing a problem that prevented surcharge from showing on simple products

### DIFF
--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" ?>
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_layout.xsd">
     <referenceBlock name="product.info.addtocart">
-        <block name="product.info.addtocart.shipping_surcharge" as="shipping_surcharge" class="SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount\Product" template="price/shipping_surcharge_amount.phtml" />
+        <block name="product.info.addtocart.shipping_surcharge" as="shipping_surcharge" class="SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount\Product" template="SwiftOtter_ShippingSurcharge::price/shipping_surcharge_amount.phtml" />
     </referenceBlock>
 
     <referenceBlock name="product.info.addtocart.additional">
-        <block name="product.info.addtocart.shipping_surcharge" as="shipping_surcharge" class="SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount\Product" template="price/shipping_surcharge_amount.phtml" />
+        <block name="product.info.addtocart.additional.shipping_surcharge" as="shipping_surcharge" class="SwiftOtter\ShippingSurcharge\Block\ShippingSurchargeAmount\Product" template="SwiftOtter_ShippingSurcharge::price/shipping_surcharge_amount.phtml" />
     </referenceBlock>
 </layout>


### PR DESCRIPTION
The names of the two blocks were identical which caused the second one to load. This made it unavailable for simple products which use the `product.info.addtocart` block. By changing the name, it corrects the issue.