### PR TITLE
Invoice and Creditmemo fixes and improvements

### DIFF
--- a/Block/Adminhtml/Order/Creditmemo/Surcharge.php
+++ b/Block/Adminhtml/Order/Creditmemo/Surcharge.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @by SwiftOtter, Inc. 4/19/17
+ * @by SwiftOtter, Inc. 4/11/17
  * @website https://swiftotter.com
  **/
 
@@ -19,7 +19,7 @@ class Surcharge extends \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals
         \SwiftOtter\ShippingSurcharge\Config\Info $configInfo,
         array $data = []
     ) {
-        parent::__construct($context, $registry, $adminHelper, $data);
         $this->configInfo = $configInfo;
+        parent::__construct($context, $registry, $adminHelper, $data);
     }
 }

--- a/Block/Adminhtml/Order/Creditmemo/SurchargeAdjustment.php
+++ b/Block/Adminhtml/Order/Creditmemo/SurchargeAdjustment.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @by SwiftOtter, Inc. 4/19/17
+ * @website https://swiftotter.com
+ **/
+
+namespace SwiftOtter\ShippingSurcharge\Block\Adminhtml\Order\Creditmemo;
+
+use SwiftOtter\ShippingSurcharge\Model\Surcharge as SurchargeModel;
+
+class SurchargeAdjustment extends \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals
+{
+    private $configInfo;
+    /**
+     * @var \Magento\Framework\Pricing\PriceCurrencyInterface
+     */
+    private $priceCurrency;
+
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Sales\Helper\Admin $adminHelper,
+        \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
+        \SwiftOtter\ShippingSurcharge\Config\Info $configInfo,
+        array $data = []
+    ) {
+        parent::__construct($context, $registry, $adminHelper, $data);
+        $this->configInfo = $configInfo;
+        $this->priceCurrency = $priceCurrency;
+    }
+
+    public function initTotals()
+    {
+        /** @var $parent \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals */
+        $parent = $this->getParentBlock();
+
+        $total = new \Magento\Framework\DataObject([
+            'code' => 'shipping_surcharge_adjustment',
+            'block_name' => $this->getNameInLayout()
+        ]);
+
+        $parent->addTotal($total);
+        return $this;
+    }
+
+    public function showSurcharge()
+    {
+        return ($this->configInfo->isFeatureEnabled() && $this->getSource());
+    }
+
+    public function getSurchargeAmount()
+    {
+        return $this->getSource()->getData(SurchargeModel::SURCHARGE);
+    }
+
+    public function getFormattedSurchargeAmount()
+    {
+        return $this->priceCurrency->format($this->getSource()->getData(SurchargeModel::SURCHARGE));
+    }
+}

--- a/Model/Order/Creditmemo/CreditmemoPlugin.php
+++ b/Model/Order/Creditmemo/CreditmemoPlugin.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @by SwiftOtter, Inc. 4/27/17
+ * @website https://swiftotter.com
+ **/
+
+namespace SwiftOtter\ShippingSurcharge\Model\Order\Creditmemo;
+
+use SwiftOtter\ShippingSurcharge\Model\Surcharge as SurchargeModel;
+
+class CreditmemoPlugin
+{
+    public function beforeCreateByInvoice(\Magento\Sales\Model\Order\CreditmemoFactory $context, \Magento\Sales\Model\Order\Invoice $invoice, array $data)
+    {
+        if (isset($data[SurchargeModel::SURCHARGE_REQUESTED_REFUND]) && $data[SurchargeModel::SURCHARGE_REQUESTED_REFUND]) {
+            $invoice->setData(SurchargeModel::SURCHARGE_REQUESTED_REFUND, $data[SurchargeModel::SURCHARGE_REQUESTED_REFUND]);
+        }
+
+        return [$invoice, $data];
+    }
+
+    public function beforeCreateByOrder(\Magento\Sales\Model\Order\CreditmemoFactory $context, \Magento\Sales\Model\Order $order, array $data = [])
+    {
+        if (isset($data[SurchargeModel::SURCHARGE_REQUESTED_REFUND]) && $data[SurchargeModel::SURCHARGE_REQUESTED_REFUND]) {
+            $order->setData(SurchargeModel::SURCHARGE_REQUESTED_REFUND, $data[SurchargeModel::SURCHARGE_REQUESTED_REFUND]);
+        }
+
+        return [$order, $data];
+    }
+}

--- a/Model/Order/Creditmemo/ItemPlugin.php
+++ b/Model/Order/Creditmemo/ItemPlugin.php
@@ -13,10 +13,16 @@ class ItemPlugin
     public function afterCalcRowTotal(\Magento\Sales\Model\Order\Creditmemo\Item $item)
     {
         $orderItem = $item->getOrderItem();
+        $itemQty = $item->getQty();
 
-        if ($orderItem->getData(SurchargeModel::SURCHARGE) && $item->getQty() > 0) {
-            $item->setData(SurchargeModel::SURCHARGE, $orderItem->getData(SurchargeModel::SURCHARGE));
-            $item->setData(SurchargeModel::BASE_SURCHARGE, $orderItem->getData(SurchargeModel::BASE_SURCHARGE));
+        if ($orderItem->getData(SurchargeModel::SURCHARGE) && $itemQty > 0) {
+            $item->setData(SurchargeModel::SURCHARGE, $this->calculateSurchargeFrom($orderItem, $itemQty));
+            $item->setData(SurchargeModel::BASE_SURCHARGE, $this->calculateSurchargeFrom($orderItem, $itemQty, SurchargeModel::BASE_SURCHARGE));
         }
+    }
+
+    private function calculateSurchargeFrom(\Magento\Sales\Model\Order\Item $orderItem, $itemQty, $key = SurchargeModel::SURCHARGE)
+    {
+        return (int) ceil(($orderItem->getData($key) / $orderItem->getQtyOrdered()) * $itemQty);
     }
 }

--- a/Model/Order/Creditmemo/Total/Surcharge.php
+++ b/Model/Order/Creditmemo/Total/Surcharge.php
@@ -15,8 +15,14 @@ class Surcharge extends \Magento\Sales\Model\Order\Creditmemo\Total\AbstractTota
      */
     private $priceCurrency;
 
-    public function __construct(\Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency, array $data = [])
-    {
+    /**
+     * @param \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
+        array $data = []
+    ) {
         parent::__construct($data);
         $this->priceCurrency = $priceCurrency;
     }

--- a/Model/Order/Creditmemo/Total/Surcharge.php
+++ b/Model/Order/Creditmemo/Total/Surcharge.php
@@ -6,21 +6,17 @@
 
 namespace SwiftOtter\ShippingSurcharge\Model\Order\Creditmemo\Total;
 
-use Magento\Framework\Pricing\PriceCurrencyInterface;
 use SwiftOtter\ShippingSurcharge\Model\Surcharge as SurchargeModel;
 
 class Surcharge extends \Magento\Sales\Model\Order\Creditmemo\Total\AbstractTotal
 {
+    /**
+     * @var \Magento\Framework\Pricing\PriceCurrencyInterface
+     */
     private $priceCurrency;
 
-    /**
-     * @param PriceCurrencyInterface $priceCurrency
-     * @param array $data
-     */
-    public function __construct(
-        PriceCurrencyInterface $priceCurrency,
-        array $data = []
-    ) {
+    public function __construct(\Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency, array $data = [])
+    {
         parent::__construct($data);
         $this->priceCurrency = $priceCurrency;
     }
@@ -31,6 +27,73 @@ class Surcharge extends \Magento\Sales\Model\Order\Creditmemo\Total\AbstractTota
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function collect(\Magento\Sales\Model\Order\Creditmemo $creditmemo)
+    {
+        $order = $creditmemo->getOrder();
+
+        list($allowedSurcharged, $baseAllowedSurcharged) = $this->getAllowedAmounts($order);
+        $desiredAmount = (float) $order->getData(SurchargeModel::SURCHARGE_REQUESTED_REFUND);
+
+        if ($desiredAmount && $desiredAmount <= $allowedSurcharged) {
+            $surcharge = $desiredAmount;
+            $baseSurcharge = $desiredAmount;
+        } else {
+            list($surcharge, $baseSurcharge) = $this->calculateSurchargeAmounts($creditmemo);
+        }
+
+        if ($surcharge > $allowedSurcharged) {
+            $surcharge = $allowedSurcharged;
+            $baseSurcharge = $baseAllowedSurcharged;
+        }
+
+        $surcharge = $this->priceCurrency->round($surcharge);
+        $baseSurcharge = $this->priceCurrency->round($baseSurcharge);
+
+        $this->setCreditmemoData($creditmemo, $surcharge, $baseSurcharge);
+        $this->setOrderData($order, $surcharge, $baseSurcharge);
+
+        return $this;
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order\Creditmemo $creditmemo
+     * @param $surcharge
+     * @param $baseSurcharge
+     */
+    public function setCreditmemoData(\Magento\Sales\Model\Order\Creditmemo $creditmemo, $surcharge, $baseSurcharge)
+    {
+        $creditmemo->setData(SurchargeModel::SURCHARGE, $surcharge);
+        $creditmemo->setData(SurchargeModel::BASE_SURCHARGE, $baseSurcharge);
+        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $surcharge);
+        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSurcharge);
+    }
+
+    /**
+     * @param $order
+     * @param $surcharge
+     * @param $baseSurcharge
+     */
+    public function setOrderData(\Magento\Sales\Model\Order $order, $surcharge, $baseSurcharge)
+    {
+        $order->setData(SurchargeModel::SURCHARGE_REFUNDED, ($order->getData(SurchargeModel::SURCHARGE_REFUNDED) + $surcharge));
+        $order->setData(SurchargeModel::BASE_SURCHARGE_REFUNDED, ($order->getData(SurchargeModel::BASE_SURCHARGE_REFUNDED) + $baseSurcharge));
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    private function getAllowedAmounts(\Magento\Sales\Model\Order $order): array
+    {
+        $allowedSurcharged = $order->getData(SurchargeModel::SURCHARGE) - $order->getData(SurchargeModel::SURCHARGE_REFUNDED);
+        $baseAllowedSurcharged = $order->getData(SurchargeModel::BASE_SURCHARGE) - $order->getData(SurchargeModel::BASE_SURCHARGE_REFUNDED);
+        return [$allowedSurcharged, $baseAllowedSurcharged];
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order\Creditmemo $creditmemo
+     * @return array
+     */
+    private function calculateSurchargeAmounts(\Magento\Sales\Model\Order\Creditmemo $creditmemo): array
     {
         $surcharge = 0;
         $baseSurcharge = 0;
@@ -46,11 +109,6 @@ class Surcharge extends \Magento\Sales\Model\Order\Creditmemo\Total\AbstractTota
             $baseSurcharge += $item->getData(SurchargeModel::BASE_SURCHARGE);
         }
 
-        $creditmemo->setData(SurchargeModel::SURCHARGE, $surcharge);
-        $creditmemo->setData(SurchargeModel::BASE_SURCHARGE, $baseSurcharge);
-        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $surcharge);
-        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseSurcharge);
-
-        return $this;
+        return [$surcharge, $baseSurcharge];
     }
 }

--- a/Model/Surcharge.php
+++ b/Model/Surcharge.php
@@ -13,5 +13,7 @@ class Surcharge
     const BASE_SURCHARGE = 'base_shipping_surcharge';
 
     const SURCHARGE_REFUNDED = 'shipping_surcharge_refunded';
-    const BASE_SURCHARGE_REFUNDED = 'shipping_surcharge_refunded';
+    const BASE_SURCHARGE_REFUNDED = 'base_shipping_surcharge_refunded';
+
+    const SURCHARGE_REQUESTED_REFUND = 'shipping_surcharge_refund_request';
 }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -78,5 +78,10 @@ class UpgradeData implements UpgradeDataInterface
             $salesSetup->addAttribute('creditmemo_item', Surcharge::BASE_SURCHARGE, ['type' => 'decimal']);
             $salesSetup->addAttribute('creditmemo_item', Surcharge::SURCHARGE, ['type' => 'decimal']);
         }
+
+        if (version_compare($context->getVersion(), 2.1) === ModuleDataSetupInterface::VERSION_COMPARE_LOWER) {
+            $salesSetup->addAttribute('order', Surcharge::SURCHARGE_REFUNDED, ['type' => 'decimal' ]);
+            $salesSetup->addAttribute('order', Surcharge::BASE_SURCHARGE_REFUNDED, ['type' => 'decimal' ]);
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "magento/module-quote": "100.1.*"
   },
   "type": "magento2-module",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "autoload": {
     "files": [
       "registration.php"

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Sales\Model\Order\CreditmemoFactory">
+        <plugin name="surcharge_memo" type="SwiftOtter\ShippingSurcharge\Model\Order\Creditmemo\CreditmemoPlugin" sortOrder="50"/>
+    </type>
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SwiftOtter_ShippingSurcharge" setup_version="2.0.0">
+    <module name="SwiftOtter_ShippingSurcharge" setup_version="2.1.0">
         <sequence>
             <module name="Magento_Shipping" />
         </sequence>

--- a/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -3,7 +3,9 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_totals">
-            <block class="SwiftOtter\ShippingSurcharge\Block\Adminhtml\Order\Creditmemo\Surcharge" name="shipping_surcharge"/>
+            <block class="SwiftOtter\ShippingSurcharge\Block\Adminhtml\Order\Creditmemo\SurchargeAdjustment"
+                   name="shipping_surcharge"
+                   template="SwiftOtter_ShippingSurcharge::order/creditmemo/create/adjustments.phtml" />
         </referenceBlock>
     </body>
 </page>

--- a/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -3,7 +3,9 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_totals">
-            <block class="SwiftOtter\ShippingSurcharge\Block\Adminhtml\Order\Creditmemo\Surcharge" name="shipping_surcharge"/>
+            <block class="SwiftOtter\ShippingSurcharge\Block\Adminhtml\Order\Creditmemo\SurchargeAdjustment"
+                   name="shipping_surcharge"
+                   template="SwiftOtter_ShippingSurcharge::order/creditmemo/create/adjustments.phtml" />
         </referenceBlock>
     </body>
 </page>

--- a/view/adminhtml/templates/order/creditmemo/create/adjustments.phtml
+++ b/view/adminhtml/templates/order/creditmemo/create/adjustments.phtml
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @by SwiftOtter, Inc., 4/27/17
+ * @website https://swiftotter.com
+ **/
+
+// @codingStandardsIgnoreFile
+/** @var $block \SwiftOtter\ShippingSurcharge\Block\Adminhtml\Order\Creditmemo\SurchargeAdjustment */
+?>
+<?php if ($block->showSurcharge()): ?>
+    <tr>
+        <td class="label"><?php /* @escapeNotVerified */ echo __('Additional Shipping Charge') ?><div id="additional_shipping_charge"></div></td>
+        <td>
+            <span>
+                <span class="price" id="additional_shipping_charge_edit"><?php echo $this->getFormattedSurchargeAmount(); ?></span>
+            </span>
+            <input type="text"
+                   name="creditmemo[<?php echo \SwiftOtter\ShippingSurcharge\Model\Surcharge::SURCHARGE_REQUESTED_REFUND; ?>]"
+                   data-value="<?php /* @escapeNotVerified */ echo $block->getSurchargeAmount() ?>"
+                   class="input-text admin__control-text not-negative-amount hidden"
+                   id="additional_shipping_charge_value"/>
+            <script>
+                require(['prototype'], function(){
+
+                document.getElementById('additional_shipping_charge_edit').addEventListener('click', function (e) {
+                    e.currentTarget.classList.add('hidden');
+                    var shippingInput = document.getElementById('additional_shipping_charge_value');
+                    shippingInput.classList.remove('hidden');
+                    shippingInput.value = shippingInput.getAttribute('data-value');
+                });
+
+                //<![CDATA[
+                Validation.addAllThese([
+                    ['not-negative-amount', '<?php /* @escapeNotVerified */ echo __('Please enter a positive number in this field.') ?>', function(v) {
+                        if(v.length)
+                            return /^\s*\d+([,.]\d+)*\s*%?\s*$/.test(v);
+                        else
+                            return true;
+                    }]
+                ]);
+
+                if ($('additional_shipping_charge')) {
+                    $('additional_shipping_charge').advaiceContainer = $('additional_shipping_charge');
+                    unblockSubmit('additional_shipping_charge');
+                }
+
+                function unblockSubmit(id) {
+                    $(id).observe('focus', function(event) {
+                        if ($$('button[class="scalable update-button disabled"]').size() > 0) {
+                            enableElements('submit-button');
+                        }
+                    });
+                }
+                //]]>
+
+                });
+            </script>
+        </td>
+    </tr>
+<?php endif; ?>

--- a/view/frontend/layout/sales_email_order_creditmemo_items.xml
+++ b/view/frontend/layout/sales_email_order_creditmemo_items.xml
@@ -2,6 +2,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="SwiftOtter\ShippingSurcharge\Block\Order\Creditmemo\Surcharge" name="shipping_surcharge"/>
+        <referenceBlock name="creditmemo_totals">
+            <block class="SwiftOtter\ShippingSurcharge\Block\Order\Creditmemo\Surcharge" name="shipping_surcharge"/>
+        </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
This introduces more control over the refund amount and corrects bugs relating to the quantity of invoiced items. Previously, amounts were based only on the order quantities. Now, they are based on the invoice or creditmemo items.

Adding the ability to edit the surcharge amount ended up being a little tricky. First, Magento used a `protected` method where it would be been incredibly nice for them to use a `public` method. That meant that I had to plugin to the primary methods - and `before` at that because `after` didn't get the `$data` argument that I needed. Also, when product quantity was updated, I wanted to update the surcharge amount, but there wasn't a way to differentiate a request that should be overridden vs. not. I ended up hiding the input unless the amount is clicked on, then swapping it for the input.