### PR TITLE
Built out order tests and fixed problem where floats were cast to int

### DIFF
--- a/Observer/QuoteSubmit.php
+++ b/Observer/QuoteSubmit.php
@@ -64,7 +64,7 @@ class QuoteSubmit implements ObserverInterface
 
     private function calculateTotalsFromItems(AbstractExtensibleModel ...$items) : float
     {
-        return array_reduce($items, function (int $acc, AbstractExtensibleModel $item) {
+        return array_reduce($items, function (float $acc, AbstractExtensibleModel $item) {
             $itemTotal = $this->surchargeCalculator->calculateSurchargeForItem($item);
 
             $item->setData(Surcharge::BASE_SURCHARGE, $itemTotal);

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "magento/module-quote": "100.1.*"
   },
   "type": "magento2-module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "autoload": {
     "files": [
       "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SwiftOtter_ShippingSurcharge" setup_version="2.1.0">
+    <module name="SwiftOtter_ShippingSurcharge" setup_version="2.1.1">
         <sequence>
             <module name="Magento_Shipping" />
         </sequence>


### PR DESCRIPTION
This fixes a bug where calculations could add up incorrectly when non-even shipping surcharges were used. 

It also builds out the integration test to run through order submission. 